### PR TITLE
Issue #7: Dependent-lib is now header only library.

### DIFF
--- a/dependent/CMakeLists.txt
+++ b/dependent/CMakeLists.txt
@@ -2,14 +2,4 @@ enable_testing()
 
 project(dependent)
 
-set(HEADER_FILES
-    dependent.h
-    dense_allocator.h)
-
-set(SOURCE_FILES
-    dependent.cpp
-    dense_allocator.cpp)
-
-add_library(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
-
 add_subdirectory(ut)

--- a/dependent/dense_allocator.cpp
+++ b/dependent/dense_allocator.cpp
@@ -1,1 +1,0 @@
-#include "dense_allocator.h"

--- a/dependent/dependent.cpp
+++ b/dependent/dependent.cpp
@@ -1,1 +1,0 @@
-#include "dependent.h"

--- a/dependent/ut/CMakeLists.txt
+++ b/dependent/ut/CMakeLists.txt
@@ -6,10 +6,10 @@ set(SOURCE_FILES
     dependent_ut.cpp
     future_std_stubs_ut.cpp
     stats_allocator_ut.cpp
-    )
+)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
-target_link_libraries(${PROJECT_NAME} dependent catch)
+target_link_libraries(${PROJECT_NAME} catch)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})


### PR DESCRIPTION
- Removed almost empty .cpp files.
- Everything works as before.